### PR TITLE
Add variants

### DIFF
--- a/src/helpers/fn.test.ts
+++ b/src/helpers/fn.test.ts
@@ -21,4 +21,10 @@ describe.concurrent("asyncFn", () => {
 		const result = await wrappedFn()
 		expect(result.unwrap()).toEqual(42)
 	})
+
+	it("returns Err result when provided async function returns Err", async () => {
+		const wrappedFn = asyncFn(async () => Promise.resolve(Err("rekt")))
+		const result = await wrappedFn()
+		expect(result.unwrapErr()).toEqual("rekt")
+	})
 })

--- a/src/helpers/fn.ts
+++ b/src/helpers/fn.ts
@@ -1,4 +1,9 @@
-import type {ResultValueType, ResultErrorType} from "../util"
+import type {
+	ResultValueType,
+	ResultErrorType,
+	AsyncResultValueType,
+	AsyncResultErrorType,
+} from "../util"
 import type {Result} from "../result/interface"
 import {PromiseResult} from "../result/promise"
 
@@ -9,9 +14,7 @@ export function fn<T extends (...args: any[]) => Result<any, any>>(
 }
 
 export function asyncFn<T extends (...args: any[]) => Promise<Result<any, any>>>(f: T) {
-	return function (
-		...args: Parameters<T>
-	): PromiseResult<ResultValueType<ReturnType<T>>, ResultErrorType<ReturnType<T>>> {
-		return new PromiseResult(f(...args))
+	return function (...args: Parameters<T>) {
+		return new PromiseResult<AsyncResultValueType<T>, AsyncResultErrorType<T>>(f(...args))
 	}
 }

--- a/src/helpers/try.ts
+++ b/src/helpers/try.ts
@@ -1,5 +1,5 @@
 import {Panic} from "../error/panic"
-import {type ErrorHandler, type ResultError, type StdError, toStdError} from "../error/result_error"
+import {type ErrorHandler, type ResultError, StdError, toStdError} from "../error/result_error"
 import {Err} from "../result/err"
 import type {Result} from "../result/interface"
 import {Ok} from "../result/ok"
@@ -35,7 +35,7 @@ export function tryFnWith<T, E extends ResultError>(
 }
 
 export function tryPromise<T>(promise: Promise<T>): PromiseResult<T, StdError> {
-	return new PromiseResult(
+	return new PromiseResult<T, StdError>(
 		promise.then(
 			(value) => Ok(value),
 			(error: unknown) => Err(toStdError(error)),

--- a/src/option/interface.ts
+++ b/src/option/interface.ts
@@ -31,4 +31,17 @@ export interface OptionMethods<T> {
 	toJSON(): {meta: "Some"; data: T} | {meta: "None"}
 }
 
-export type Option<T> = Some<T> | None
+export type SomeVariant<T> = {
+	readonly some: true
+	readonly none: false
+	readonly value: T
+}
+
+export type NoneVariant = {
+	readonly some: false
+	readonly none: true
+}
+
+export type OptionVariants<T> = SomeVariant<T> | NoneVariant
+
+export type Option<T> = OptionVariants<T> & OptionMethods<T>

--- a/src/option/interface.ts
+++ b/src/option/interface.ts
@@ -31,13 +31,13 @@ export interface OptionMethods<T> {
 	toJSON(): {meta: "Some"; data: T} | {meta: "None"}
 }
 
-export type SomeVariant<T> = {
+export interface SomeVariant<T> {
 	readonly some: true
 	readonly none: false
 	readonly value: T
 }
 
-export type NoneVariant = {
+export interface NoneVariant {
 	readonly some: false
 	readonly none: true
 }

--- a/src/option/none.ts
+++ b/src/option/none.ts
@@ -1,9 +1,9 @@
 import {Panic, UnwrapPanic} from "../error/panic"
 import {inspectSymbol} from "../util"
-import type {OptionMethods, Option} from "./interface"
+import type {OptionMethods, Option, NoneVariant} from "./interface"
 import type {Some} from "./some"
 
-export class NoneImpl implements OptionMethods<never> {
+export class NoneImpl implements NoneVariant, OptionMethods<never> {
 	readonly some = false
 	readonly none = true
 

--- a/src/option/promise.test.ts
+++ b/src/option/promise.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect, vi} from "vitest"
 import {Panic, UnwrapPanic, PromiseOption, Some, None} from ".."
 
 function promiseSome<T>(value: T) {
-	return new PromiseOption(Promise.resolve(Some<T>(value)))
+	return new PromiseOption<T>(Promise.resolve(Some<T>(value)))
 }
 
 function promiseNone() {

--- a/src/option/some.ts
+++ b/src/option/some.ts
@@ -1,9 +1,9 @@
 import type {Panic} from "../error/panic"
 import {inspectSymbol} from "../util"
-import type {OptionMethods, Option} from "./interface"
+import type {OptionMethods, Option, SomeVariant} from "./interface"
 import {None} from "./none"
 
-export class SomeImpl<T> implements OptionMethods<T> {
+export class SomeImpl<T> implements SomeVariant<T>, OptionMethods<T> {
 	readonly some = true
 	readonly none = false
 	readonly value: T

--- a/src/result/err.ts
+++ b/src/result/err.ts
@@ -1,11 +1,10 @@
 import {Panic, UnwrapPanic} from "../error/panic"
 import {inspectSymbol} from "../util"
-import type {Result, ResultMethods} from "./interface"
+import type {ErrVariant, Result, ResultMethods} from "./interface"
 import type {Ok} from "./ok"
 
-export class ErrImpl<E> implements ResultMethods<never, E> {
+export class ErrImpl<E> implements ErrVariant<E>, ResultMethods<never, E> {
 	readonly ok = false
-	readonly value?: never
 	readonly err = true
 	readonly error: E
 

--- a/src/result/interface.ts
+++ b/src/result/interface.ts
@@ -49,5 +49,3 @@ export type ErrVariant<E> = {
 export type ResultVariants<T, E> = OkVariant<T> | ErrVariant<E>
 
 export type Result<T, E> = ResultVariants<T, E> & ResultMethods<T, E>
-
-const wtf = {} as Result<string, string>

--- a/src/result/interface.ts
+++ b/src/result/interface.ts
@@ -34,13 +34,13 @@ export interface ResultMethods<T, E> {
 	toJSON(): {meta: "Ok"; data: T} | {meta: "Err"; data: E}
 }
 
-export type OkVariant<T> = {
+export interface OkVariant<T> {
 	readonly ok: true
 	readonly err: false
 	readonly value: T
 }
 
-export type ErrVariant<E> = {
+export interface ErrVariant<E> {
 	readonly ok: false
 	readonly err: true
 	readonly error: E

--- a/src/result/interface.ts
+++ b/src/result/interface.ts
@@ -34,4 +34,20 @@ export interface ResultMethods<T, E> {
 	toJSON(): {meta: "Ok"; data: T} | {meta: "Err"; data: E}
 }
 
-export type Result<T, E> = Ok<T> | Err<E>
+export type OkVariant<T> = {
+	readonly ok: true
+	readonly err: false
+	readonly value: T
+}
+
+export type ErrVariant<E> = {
+	readonly ok: false
+	readonly err: true
+	readonly error: E
+}
+
+export type ResultVariants<T, E> = OkVariant<T> | ErrVariant<E>
+
+export type Result<T, E> = ResultVariants<T, E> & ResultMethods<T, E>
+
+const wtf = {} as Result<string, string>

--- a/src/result/ok.ts
+++ b/src/result/ok.ts
@@ -1,13 +1,12 @@
 import {Panic, UnwrapPanic} from "../error/panic"
 import {inspectSymbol} from "../util"
 import type {Err} from "./err"
-import type {Result, ResultMethods} from "./interface"
+import type {OkVariant, Result, ResultMethods} from "./interface"
 
-export class OkImpl<T> implements ResultMethods<T, never> {
+export class OkImpl<T> implements OkVariant<T>, ResultMethods<T, never> {
 	readonly ok = true
-	readonly value: T
 	readonly err = false
-	readonly error?: never
+	readonly value: T
 
 	constructor(value: T) {
 		this.value = value

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,28 +1,20 @@
-import type {Option} from "./option/interface"
-import type {PromiseOption} from "./option/promise"
-import type {Result} from "./result/interface"
-import type {PromiseResult} from "./result/promise"
+import type {Err} from "./result/err"
+import type {Ok} from "./result/ok"
 
 export const inspectSymbol = Symbol.for("nodejs.util.inspect.custom")
 
-export type ResultValueErrorType<T> = T extends
-	| Result<infer V, infer E>
-	| PromiseResult<infer V, infer E>
-	| Promise<Result<infer V, infer E>>
-	| ((...args: any[]) => Result<infer V, infer E>)
-	| ((...args: any[]) => PromiseResult<infer V, infer E>)
-	| ((...args: any[]) => Promise<Result<infer V, infer E>>)
+export type ResultValueErrorType<T> = T extends (...args: any[]) => Ok<infer V> | Err<infer E>
 	? {value: V; error: E}
 	: never
+
 export type ResultValueType<T> = ResultValueErrorType<T>["value"]
 export type ResultErrorType<T> = ResultValueErrorType<T>["error"]
 
-export type OptionValueType<T> = T extends
-	| Option<infer V>
-	| PromiseOption<infer V>
-	| Promise<Option<infer V>>
-	| ((...args: any[]) => Option<infer V>)
-	| ((...args: any[]) => PromiseOption<infer V>)
-	| ((...args: any[]) => Promise<Option<infer V>>)
-	? V
+export type AsyncResultValueErrorType<T> = T extends (
+	...args: any[]
+) => Promise<Ok<infer V> | Err<infer E>>
+	? {value: V; error: E}
 	: never
+
+export type AsyncResultValueType<T> = AsyncResultValueErrorType<T>["value"]
+export type AsyncResultErrorType<T> = AsyncResultValueErrorType<T>["error"]


### PR DESCRIPTION
Unfortunately, this is necessary to nicely display methods on a Result object:
```ts
export interface SomeVariant<T> {
	readonly some: true
	readonly none: false
	readonly value: T
}

export interface NoneVariant {
	readonly some: false
	readonly none: true
}

export type OptionVariants<T> = SomeVariant<T> | NoneVariant

export type Option<T> = OptionVariants<T> & OptionMethods<T>
```
See this example:
![image](https://github.com/bkiac/ruts/assets/24522620/f389d485-798d-4c64-a474-4c9e08d454da)
Using variants will force TypeScript to use the function signature defined in the `ResultMethods` interface.
![image](https://github.com/bkiac/ruts/assets/24522620/120d69f7-3c0e-4bb9-87b1-8be2f0fed7c2)

Although this looks nicer on the Result type:

```ts
type Result<T, E> = Ok<T> | Err<E>
```
This will output a function signature that's the result of the `Ok` and `Err` union:
![image](https://github.com/bkiac/ruts/assets/24522620/873f2042-5ac5-4784-849b-11f983451d35)
