### PR TITLE
Remove type predicates

### DIFF
--- a/src/option/interface.ts
+++ b/src/option/interface.ts
@@ -1,7 +1,5 @@
 import type {Panic} from "../error/panic"
 import type {inspectSymbol} from "../util"
-import type {None} from "./none"
-import type {Some} from "./some"
 
 export interface OptionMethods<T> {
 	and<U>(other: Option<U>): Option<U>
@@ -9,9 +7,6 @@ export interface OptionMethods<T> {
 	expect(panic: string | Panic): T
 	filter(f: (value: T) => boolean): Option<T>
 	inspect(f: (value: T) => void): Option<T>
-	isNone(): this is None
-	isSome(): this is Some<T>
-	isSomeAnd(f: (value: T) => boolean): this is Some<T>
 	map<U>(f: (value: T) => U): Option<U>
 	mapOr<A, B>(defaultValue: A, f: (value: T) => B): A | B
 	mapOrElse<A, B>(defaultValue: () => A, f: (value: T) => B): A | B

--- a/src/option/none.ts
+++ b/src/option/none.ts
@@ -1,7 +1,6 @@
 import {Panic, UnwrapPanic} from "../error/panic"
 import {inspectSymbol} from "../util"
 import type {OptionMethods, Option, NoneVariant} from "./interface"
-import type {Some} from "./some"
 
 export class NoneImpl implements NoneVariant, OptionMethods<never> {
 	readonly some = false
@@ -25,18 +24,6 @@ export class NoneImpl implements NoneVariant, OptionMethods<never> {
 
 	inspect(_f: (value: never) => void) {
 		return this
-	}
-
-	isNone(): this is None {
-		return true
-	}
-
-	isSome(): this is Some<never> {
-		return false
-	}
-
-	isSomeAnd(_f: (value: never) => boolean): this is Some<never> {
-		return false
 	}
 
 	map<U>(_f: (value: never) => U) {

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -98,47 +98,6 @@ describe.concurrent("inspect", () => {
 	})
 })
 
-describe.concurrent("isNone", () => {
-	it("returns false for a Some option", () => {
-		const option = Some(42)
-		expect(option.isNone()).toEqual(false)
-	})
-
-	it("returns true for a None option", () => {
-		const option = None
-		expect(option.isNone()).toEqual(true)
-	})
-})
-
-describe.concurrent("isSome", () => {
-	it("returns true for a Some option", () => {
-		const option = Some(42)
-		expect(option.isSome()).toEqual(true)
-	})
-
-	it("returns false for a None option", () => {
-		const option = None
-		expect(option.isSome()).toEqual(false)
-	})
-})
-
-describe.concurrent("isSomeAnd", () => {
-	it("returns true for a Some option when the predicate returns true", () => {
-		const option = Some(42)
-		expect(option.isSomeAnd((value) => value === 42)).toEqual(true)
-	})
-
-	it("returns false for a Some option when the predicate returns false", () => {
-		const option = Some(42)
-		expect(option.isSomeAnd((value) => value !== 42)).toEqual(false)
-	})
-
-	it("returns false for a None option", () => {
-		const option = None
-		expect(option.isSomeAnd((value) => value === 42)).toEqual(false)
-	})
-})
-
 describe.concurrent("map", () => {
 	it("returns the mapped value for a Some option", () => {
 		const option = Some(42)

--- a/src/option/promise.test.ts
+++ b/src/option/promise.test.ts
@@ -90,47 +90,6 @@ describe.concurrent("inspect", () => {
 	})
 })
 
-describe.concurrent("isNone", () => {
-	it("returns false when called on a Some option", async () => {
-		const option = promiseSome(42)
-		await expect(option.isNone()).resolves.toEqual(false)
-	})
-
-	it("returns true when called on a None option", async () => {
-		const option = promiseNone()
-		await expect(option.isNone()).resolves.toEqual(true)
-	})
-})
-
-describe.concurrent("isSome", () => {
-	it("returns true when called on a Some option", async () => {
-		const option = promiseSome(42)
-		await expect(option.isSome()).resolves.toEqual(true)
-	})
-
-	it("returns false when called on a None option", async () => {
-		const option = promiseNone()
-		await expect(option.isSome()).resolves.toEqual(false)
-	})
-})
-
-describe.concurrent("isSomeAnd", () => {
-	it("returns true when called on a Some option and the predicate returns true", async () => {
-		const option = promiseSome(42)
-		await expect(option.isSomeAnd((value) => value === 42)).resolves.toEqual(true)
-	})
-
-	it("returns false when called on a Some option and the predicate returns false", async () => {
-		const option = promiseSome(42)
-		await expect(option.isSomeAnd((value) => value !== 42)).resolves.toEqual(false)
-	})
-
-	it("returns false when called on a None option", async () => {
-		const option = promiseNone()
-		await expect(option.isSomeAnd((value) => value === 42)).resolves.toEqual(false)
-	})
-})
-
 describe.concurrent("map", () => {
 	it("returns the mapped value for a Some option", async () => {
 		const option = promiseSome(42)

--- a/src/option/promise.ts
+++ b/src/option/promise.ts
@@ -50,18 +50,6 @@ export class PromiseOption<T> implements PromiseLike<Option<T>> {
 		return new PromiseOption<T>(this.then((option) => option.inspect(f)))
 	}
 
-	async isNone() {
-		return (await this).isNone()
-	}
-
-	async isSome() {
-		return (await this).isSome()
-	}
-
-	async isSomeAnd(f: (value: T) => boolean) {
-		return (await this).isSomeAnd(f)
-	}
-
 	async map<U>(f: (value: T) => U) {
 		return (await this).map(f)
 	}

--- a/src/option/some.ts
+++ b/src/option/some.ts
@@ -33,18 +33,6 @@ export class SomeImpl<T> implements SomeVariant<T>, OptionMethods<T> {
 		return this
 	}
 
-	isNone(): this is None {
-		return false
-	}
-
-	isSome(): this is Some<T> {
-		return true
-	}
-
-	isSomeAnd(f: (value: T) => boolean): this is Some<T> {
-		return f(this.value)
-	}
-
 	map<U>(f: (value: T) => U) {
 		return Some(f(this.value))
 	}
@@ -78,7 +66,7 @@ export class SomeImpl<T> implements SomeVariant<T>, OptionMethods<T> {
 	}
 
 	xor<U>(other: Option<U>) {
-		return other.isSome() ? None : this
+		return other.some ? other : this
 	}
 
 	into() {

--- a/src/option/some.ts
+++ b/src/option/some.ts
@@ -66,7 +66,7 @@ export class SomeImpl<T> implements SomeVariant<T>, OptionMethods<T> {
 	}
 
 	xor<U>(other: Option<U>) {
-		return other.some ? other : this
+		return other.some ? None : this
 	}
 
 	into() {

--- a/src/result/err.ts
+++ b/src/result/err.ts
@@ -1,7 +1,6 @@
 import {Panic, UnwrapPanic} from "../error/panic"
 import {inspectSymbol} from "../util"
 import type {ErrVariant, Result, ResultMethods} from "./interface"
-import type {Ok} from "./ok"
 
 export class ErrImpl<E> implements ErrVariant<E>, ResultMethods<never, E> {
 	readonly ok = false
@@ -38,22 +37,6 @@ export class ErrImpl<E> implements ErrVariant<E>, ResultMethods<never, E> {
 	inspectErr(f: (error: E) => void) {
 		f(this.error)
 		return this
-	}
-
-	isErr(): this is Err<E> {
-		return true
-	}
-
-	isErrAnd(f: (error: E) => boolean): this is Err<E> {
-		return f(this.error)
-	}
-
-	isOk(): this is Ok<never> {
-		return false
-	}
-
-	isOkAnd(_f: (value: never) => boolean): this is Ok<never> {
-		return false
 	}
 
 	map<U>(_f: (value: never) => U) {

--- a/src/result/interface.ts
+++ b/src/result/interface.ts
@@ -1,7 +1,5 @@
 import type {Panic} from "../error/panic"
 import type {inspectSymbol} from "../util"
-import type {Err} from "./err"
-import type {Ok} from "./ok"
 
 export interface ResultMethods<T, E> {
 	and<U, F>(other: Result<U, F>): Result<U, E | F>
@@ -10,10 +8,6 @@ export interface ResultMethods<T, E> {
 	expectErr(panic: string | Panic): E
 	inspect(f: (value: T) => void): Result<T, E>
 	inspectErr(f: (error: E) => void): Result<T, E>
-	isErr(): this is Err<E>
-	isErrAnd(f: (error: E) => boolean): this is Err<E>
-	isOk(): this is Ok<T>
-	isOkAnd(f: (value: T) => boolean): this is Ok<T>
 	map<U>(f: (value: T) => U): Result<U, E>
 	mapErr<F>(f: (error: E) => F): Result<T, F>
 	mapOr<A, B>(defaultValue: A, f: (value: T) => B): A | B

--- a/src/result/ok.ts
+++ b/src/result/ok.ts
@@ -1,6 +1,5 @@
 import {Panic, UnwrapPanic} from "../error/panic"
 import {inspectSymbol} from "../util"
-import type {Err} from "./err"
 import type {OkVariant, Result, ResultMethods} from "./interface"
 
 export class OkImpl<T> implements OkVariant<T>, ResultMethods<T, never> {
@@ -38,22 +37,6 @@ export class OkImpl<T> implements OkVariant<T>, ResultMethods<T, never> {
 
 	inspectErr(_f: (error: never) => void) {
 		return this
-	}
-
-	isErr(): this is Err<never> {
-		return false
-	}
-
-	isErrAnd(_f: (error: never) => boolean): this is Err<never> {
-		return false
-	}
-
-	isOk(): this is Ok<T> {
-		return true
-	}
-
-	isOkAnd(f: (value: T) => boolean): this is Ok<T> {
-		return f(this.value)
 	}
 
 	map<U>(f: (value: T) => U) {

--- a/src/result/promise.test.ts
+++ b/src/result/promise.test.ts
@@ -137,64 +137,6 @@ describe.concurrent("inspectErr", async () => {
 	})
 })
 
-describe.concurrent("isErr", () => {
-	it("returns false for an Ok result", async () => {
-		const result = new PromiseResult(Promise.resolve(Ok()))
-		await expect(result.isErr()).resolves.toEqual(false)
-	})
-
-	it("returns true for an Err result", async () => {
-		const result = new PromiseResult(Promise.resolve(Err(new Error("Test error"))))
-		await expect(result.isErr()).resolves.toEqual(true)
-	})
-})
-
-describe.concurrent("isErrAnd", () => {
-	it("returns false for an Ok result", async () => {
-		const result = new PromiseResult(Promise.resolve(Ok()))
-		await expect(result.isErrAnd(() => true)).resolves.toEqual(false)
-	})
-
-	it("returns true for an Err result when the provided function returns true", async () => {
-		const result = new PromiseResult(Promise.resolve(Err(new Error("Test error"))))
-		await expect(result.isErrAnd(() => true)).resolves.toEqual(true)
-	})
-
-	it("returns false for an Err result when the provided function returns false", async () => {
-		const result = new PromiseResult(Promise.resolve(Err(new Error("Test error"))))
-		await expect(result.isErrAnd(() => false)).resolves.toEqual(false)
-	})
-})
-
-describe.concurrent("isOk", () => {
-	it("returns true for an Ok result", async () => {
-		const result = new PromiseResult(Promise.resolve(Ok()))
-		await expect(result.isOk()).resolves.toEqual(true)
-	})
-
-	it("returns false for an Err result", async () => {
-		const result = new PromiseResult(Promise.resolve(Err(new Error("Test error"))))
-		await expect(result.isOk()).resolves.toEqual(false)
-	})
-})
-
-describe.concurrent("isOkAnd", () => {
-	it("returns true for an Ok result when the provided function returns true", async () => {
-		const result = new PromiseResult(Promise.resolve(Ok()))
-		await expect(result.isOkAnd(() => true)).resolves.toEqual(true)
-	})
-
-	it("returns false for an Ok result when the provided function returns false", async () => {
-		const result = new PromiseResult(Promise.resolve(Ok()))
-		await expect(result.isOkAnd(() => false)).resolves.toEqual(false)
-	})
-
-	it("returns false for an Err result", async () => {
-		const result = new PromiseResult(Promise.resolve(Err(new Error("Test error"))))
-		await expect(result.isOkAnd(() => true)).resolves.toEqual(false)
-	})
-})
-
 describe.concurrent("map", () => {
 	it("returns the mapped value for an Ok result", async () => {
 		const result = new PromiseResult(Promise.resolve(Ok(42)))

--- a/src/result/promise.ts
+++ b/src/result/promise.ts
@@ -56,22 +56,6 @@ export class PromiseResult<T, E> implements PromiseLike<Result<T, E>> {
 		return new PromiseResult<T, E>(this.then((result) => result.inspectErr(f)))
 	}
 
-	async isErr(): Promise<boolean> {
-		return (await this).isErr()
-	}
-
-	async isErrAnd(f: (error: E) => boolean): Promise<boolean> {
-		return (await this).isErrAnd(f)
-	}
-
-	async isOk(): Promise<boolean> {
-		return (await this).isOk()
-	}
-
-	async isOkAnd(f: (value: T) => boolean): Promise<boolean> {
-		return (await this).isOkAnd(f)
-	}
-
 	map<U>(f: (value: T) => U): PromiseResult<U, E> {
 		return new PromiseResult(this.then((result) => result.map(f)))
 	}

--- a/src/result/result.test.ts
+++ b/src/result/result.test.ts
@@ -139,54 +139,6 @@ describe.concurrent("inspectErr", () => {
 	})
 })
 
-describe.concurrent("isErr", () => {
-	it("returns false for an Ok result", () => {
-		const result = Ok(42)
-		expect(result.isErr()).toEqual(false)
-	})
-
-	it("returns true for an Err result", () => {
-		const result = Err("error")
-		expect(result.isErr()).toEqual(true)
-	})
-})
-
-describe.concurrent("isErrAnd", () => {
-	it("returns false for an Ok result", () => {
-		const result = Ok(42)
-		expect(result.isErrAnd(() => true)).toEqual(false)
-	})
-
-	it("returns true for an Err result", () => {
-		const result = Err("error")
-		expect(result.isErrAnd(() => true)).toEqual(true)
-	})
-})
-
-describe.concurrent("isOk", () => {
-	it("returns true for an Ok result", () => {
-		const result = Ok(42)
-		expect(result.isOk()).toEqual(true)
-	})
-
-	it("returns false for an Err result", () => {
-		const result = Err("error")
-		expect(result.isOk()).toEqual(false)
-	})
-})
-
-describe.concurrent("isOkAnd", () => {
-	it("returns true for an Ok result", () => {
-		const result = Ok(42)
-		expect(result.isOkAnd(() => true)).toEqual(true)
-	})
-
-	it("returns false for an Err result", () => {
-		const result = Err("error")
-		expect(result.isOkAnd(() => true)).toEqual(false)
-	})
-})
-
 describe.concurrent("map", () => {
 	it("returns the mapped value for an Ok result", () => {
 		const result = Ok(42)


### PR DESCRIPTION
This PR removes type predicates because they're not very useful compared to the static properties that enable the discriminated union behavior, i.e., TypeScript can't know that if `isOk` is `true` that means it can't be an `Err`.